### PR TITLE
Fix for decimal separator in other locales

### DIFF
--- a/Scripts/JsonValue.cs
+++ b/Scripts/JsonValue.cs
@@ -85,12 +85,12 @@ namespace UniJSON
 
         public Single GetSingle()
         {
-            return Single.Parse(Segment.ToString());
+            return Single.Parse(Segment.ToString(), CultureInfo.InvariantCulture);
         }
 
         public Double GetDouble()
         {
-            return Double.Parse(Segment.ToString());
+            return Double.Parse(Segment.ToString(), CultureInfo.InvariantCulture);
         }
 
         public String GetString()


### PR DESCRIPTION
Similar to https://github.com/ousttrue/UniGLTF/pull/11 there is floating number parsing in JsonValue.cs that needs to be done with the invariant culture to make sure it uses the dot as a decimal separator regardless of the OS settings.